### PR TITLE
Ignore .ipynb_checkpoints/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.ipynb_checkpoints/


### PR DESCRIPTION
This PR adds a `.gitignore` file to ignore `.ipynb_checkpoints/` directories created by `jupyter notebook`.
